### PR TITLE
Fix for the Timeline library option

### DIFF
--- a/src/Mvc/Controller/Plugin/TimelineData.php
+++ b/src/Mvc/Controller/Plugin/TimelineData.php
@@ -51,8 +51,10 @@ class TimelineData extends AbstractPlugin
             if ($itemTitle) {
                 $itemTitle = strip_tags($itemTitle->value());
             }
-            $itemDescription = $item->value($propertyItemDescription, ['type' => 'literal', 'default' => '']);
-            if ($itemDescription) {
+            $itemDescription = $item->value($propertyItemDescription, ['default' => '']);
+            if ($itemDescription && $itemDescription->type() == 'resource:item') {
+                $itemDescription = $this->snippet($itemDescription->valueResource()->displayTitle(), 200);
+            } else {
                 $itemDescription = $this->snippet($itemDescription->value(), 200);
             }
             $itemDatesEnd = $propertyItemDateEnd

--- a/src/Site/BlockLayout/Timeline.php
+++ b/src/Site/BlockLayout/Timeline.php
@@ -101,14 +101,14 @@ class Timeline extends AbstractBlockLayout
                 $view->headLink()->appendStylesheet('//cdn.knightlab.com/libs/timeline3/latest/css/timeline.css');
                 $view->headScript()->appendFile('//cdn.knightlab.com/libs/timeline3/latest/js/timeline.js');
                 break;
-        
+
             case 'simile_online':
                 $view->headLink()->appendStylesheet($view->assetUrl('css/timeline.css', 'Timeline'));
                 $view->headScript()->appendFile($view->assetUrl('js/timeline.js', 'Timeline'));
                 $view->headScript()->appendFile('//api.simile-widgets.org/timeline/2.3.1/timeline-api.js?bundle=true');
                 $view->headScript()->appendScript('SimileAjax.History.enabled = false; window.jQuery = SimileAjax.jQuery;');
                 break;
-        
+
             case 'simile':
             default:
                 $view->headLink()->appendStylesheet($view->assetUrl('css/timeline.css', 'Timeline'));
@@ -121,14 +121,11 @@ class Timeline extends AbstractBlockLayout
                 $view->headScript()->appendScript('SimileAjax.History.enabled = false; // window.jQuery = SimileAjax.jQuery;');
                 break;
         }
-        
-        return $view->partial(
-            'common/block-layout/timeline_' . $library,
-            [
-                'blockId' => $block->id(),
-                'data' => $data,
-            ]
-        );
+
+        return $view->partial('common/block-layout/timeline_' . $library, [
+            'blockId' => $block->id(),
+            'data' => $data
+        ]);
     }
 
     public function onHydrate(SitePageBlock $block, ErrorStore $errorStore)

--- a/src/Site/BlockLayout/Timeline.php
+++ b/src/Site/BlockLayout/Timeline.php
@@ -86,22 +86,29 @@ class Timeline extends AbstractBlockLayout
         );
     }
 
-    public function prepareRender(PhpRenderer $view)
+    public function render(PhpRenderer $view, SitePageBlockRepresentation $block)
     {
-        $library = $view->setting('timeline_library');
+        $data = $block->data();
+
+        $library = $data['library'];
+        if ($library === 'simile_online') {
+            $library = 'simile';
+        }
+        unset($data['library']);
+
         switch ($library) {
             case 'knightlab':
                 $view->headLink()->appendStylesheet('//cdn.knightlab.com/libs/timeline3/latest/css/timeline.css');
                 $view->headScript()->appendFile('//cdn.knightlab.com/libs/timeline3/latest/js/timeline.js');
                 break;
-
+        
             case 'simile_online':
                 $view->headLink()->appendStylesheet($view->assetUrl('css/timeline.css', 'Timeline'));
                 $view->headScript()->appendFile($view->assetUrl('js/timeline.js', 'Timeline'));
                 $view->headScript()->appendFile('//api.simile-widgets.org/timeline/2.3.1/timeline-api.js?bundle=true');
                 $view->headScript()->appendScript('SimileAjax.History.enabled = false; window.jQuery = SimileAjax.jQuery;');
                 break;
-
+        
             case 'simile':
             default:
                 $view->headLink()->appendStylesheet($view->assetUrl('css/timeline.css', 'Timeline'));
@@ -114,18 +121,7 @@ class Timeline extends AbstractBlockLayout
                 $view->headScript()->appendScript('SimileAjax.History.enabled = false; // window.jQuery = SimileAjax.jQuery;');
                 break;
         }
-    }
-
-    public function render(PhpRenderer $view, SitePageBlockRepresentation $block)
-    {
-        $data = $block->data();
-
-        $library = $data['library'];
-        if ($library === 'simile_online') {
-            $library = 'simile';
-        }
-        unset($data['library']);
-
+        
         return $view->partial(
             'common/block-layout/timeline_' . $library,
             [

--- a/view/common/block-layout/timeline_knightlab.phtml
+++ b/view/common/block-layout/timeline_knightlab.phtml
@@ -69,8 +69,10 @@
 
           var timelineDivID = 'timeline-<?php echo $blockId; ?>';
 
+		  var timelineOptions = <?php echo $data['viewer']; ?>;
+          
           // initialize the timeline instance
-          window.timeline = new TL.Timeline(timelineDivID, slides);
+          window.timeline = new TL.Timeline(timelineDivID, slides, timelineOptions);
 
           function parseDate(entryDateString) {
             var entryDate = entryDateString;


### PR DESCRIPTION
Removed `prepareRender()` and moved its remaining content to `render()`
Should fix #4 