### PR TITLE
Apply Viewer settings for Knightlab timeline

### DIFF
--- a/view/common/block-layout/timeline_knightlab.phtml
+++ b/view/common/block-layout/timeline_knightlab.phtml
@@ -69,8 +69,10 @@
 
           var timelineDivID = 'timeline-<?php echo $blockId; ?>';
 
+		  var timelineOptions = <?php echo $data['viewer']; ?>;
+          
           // initialize the timeline instance
-          window.timeline = new TL.Timeline(timelineDivID, slides);
+          window.timeline = new TL.Timeline(timelineDivID, slides, timelineOptions);
 
           function parseDate(entryDateString) {
             var entryDate = entryDateString;


### PR DESCRIPTION
Fetches and applies the `viewer` block setting into the Knightlab Timeline view template.