### PR TITLE
Fetch all data types as description and display title for non literals

### DIFF
--- a/src/Mvc/Controller/Plugin/TimelineData.php
+++ b/src/Mvc/Controller/Plugin/TimelineData.php
@@ -51,8 +51,10 @@ class TimelineData extends AbstractPlugin
             if ($itemTitle) {
                 $itemTitle = strip_tags($itemTitle->value());
             }
-            $itemDescription = $item->value($propertyItemDescription, ['type' => 'literal', 'default' => '']);
-            if ($itemDescription) {
+            $itemDescription = $item->value($propertyItemDescription, ['default' => '']);
+            if ($itemDescription && $itemDescription->type() == 'resource:item') {
+                $itemDescription = $this->snippet($itemDescription->valueResource()->displayTitle(), 200);
+            } else {
                 $itemDescription = $this->snippet($itemDescription->value(), 200);
             }
             $itemDatesEnd = $propertyItemDateEnd


### PR DESCRIPTION
One last feature PR.
This adds the ability to select a description property that is not always a literal, especially linked resources, and displays its title.